### PR TITLE
Fix/retry modify instance attribute

### DIFF
--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -252,13 +252,24 @@ function create_and_attach_volume() {
     
     status="$?"
     if [ ! "$status" -eq 0 ]; then
-        logthis "deleting volume $volume_id"
-        aws ec2 delete-volume \
-            --region $region \
-            --volume-id $volume_id \
-        > /dev/null
-        
         error "could not attach volume to instance"
+        
+        for i in $(eval echo "{0..$max_attempts}") ; do
+            logthis "attempting to delete volume $volume_id"
+            aws ec2 delete-volume \
+                --region $region \
+                --volume-id $volume_id \
+            > /dev/null
+
+            if [ $? -eq 0 ]; then
+                logthis "Successfully deleted volume $volume_id"
+                break
+            elif [ $i -eq $max_attempts ]; then
+                logthis "Failed to delete a volume after $i attempts. Volume: $volume_id"
+            break
+            fi
+            sleep $(( 2 ** i ))
+        done
     fi
     set -e
 

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -283,7 +283,7 @@ function create_and_attach_volume() {
             logthis "volume $volume_id DeleteOnTermination ENABLED"
             break
         elif [ $i -eq $max_attempts ]; then
-            logthis "Could not modify-instance-attribute for volume $volume after $i attempts."
+            logthis "Could not modify-instance-attribute for volume $volume_id after $i attempts."
             break
         fi
         sleep $(( 2 ** i ))

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -286,7 +286,7 @@ function create_and_attach_volume() {
             logthis "Could not modify-instance-attribute for volume $volume after $i attempts."
             break
         fi
-            sleep $(( 2 ** i ))
+        sleep $(( 2 ** i ))
 
     echo $device
 }

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -254,6 +254,9 @@ function create_and_attach_volume() {
     if [ ! "$status" -eq 0 ]; then
         error "could not attach volume to instance"
         
+        # we have seen a massive proliferation of EBS volumes which are unattache. This is either because they are being made and failing to attach
+        # or they are made and attached but the "DeleteOnTermination" attribute is not being set correctly. This loop hopefully ensures the volumes
+        # which fail to attach are successfully deleted
         for i in $(eval echo "{0..$max_attempts}") ; do
             logthis "attempting to delete volume $volume_id"
             aws ec2 delete-volume \
@@ -271,7 +274,6 @@ function create_and_attach_volume() {
             sleep $(( 2 ** i ))
         done
     fi
-    set -e
 
     logthis "waiting for volume $volume_id on filesystem, device $device, $xvd_device"
     while true; do
@@ -299,6 +301,7 @@ function create_and_attach_volume() {
         fi
         sleep $(( 2 ** i ))
     done
+    set -e
 
     echo $device
 }

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -271,13 +271,22 @@ function create_and_attach_volume() {
         sleep 1
     done
 
-    # set volume delete on termination
-    aws ec2 modify-instance-attribute \
-        --region $region \
-        --instance-id $instance_id \
-        --block-device-mappings "DeviceName=$xvd_device,Ebs={DeleteOnTermination=true,VolumeId=$volume_id}" \
-    > /dev/null
-    logthis "volume $volume_id DeleteOnTermination ENABLED"
+    # set volume delete on termination, retry this with exponential backoff in the same manner as create-volume
+    for i in $(eval echo "{0..$max_attempts}") ; do
+        aws ec2 modify-instance-attribute \
+            --region $region \
+            --instance-id $instance_id \
+            --block-device-mappings "DeviceName=$xvd_device,Ebs={DeleteOnTermination=true,VolumeId=$volume_id}" \
+        > /dev/null
+
+        if [ $? -eq 0 ]; then
+            logthis "volume $volume_id DeleteOnTermination ENABLED"
+            break
+        elif [ $i -eq $max_attempts ]; then
+            logthis "Could not modify-instance-attribute for volume $volume after $i attempts."
+            break
+        fi
+            sleep $(( 2 ** i ))
 
     echo $device
 }

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -287,6 +287,7 @@ function create_and_attach_volume() {
             break
         fi
         sleep $(( 2 ** i ))
+    done
 
     echo $device
 }

--- a/config/ebs-autoscale.json
+++ b/config/ebs-autoscale.json
@@ -17,6 +17,6 @@
     },
     "logging": {
         "log_file": "/var/log/ebs-autoscale.log",
-        "log_interval": 300
+        "log_interval": 5
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ EOF
 )
 
 MOUNTPOINT=/scratch
-SIZE=256
+SIZE=100
 DEVICE=""
 FILE_SYSTEM=btrfs
 BASEDIR=$(dirname $0)

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ EOF
 )
 
 MOUNTPOINT=/scratch
-SIZE=100
+SIZE=256
 DEVICE=""
 FILE_SYSTEM=btrfs
 BASEDIR=$(dirname $0)

--- a/s3_sync.sh
+++ b/s3_sync.sh
@@ -1,1 +1,1 @@
-aws s3 sync . s3://source-code-for-download-by-ec2s/amazon-ebs-autoscale/ --exclude .git*
+aws s3 sync . s3://source-code-for-download-by-ec2s/amazon-ebs-autoscale/ --exclude "*.git*"

--- a/s3_sync.sh
+++ b/s3_sync.sh
@@ -1,1 +1,1 @@
-aws s3 sync . s3://source-code-for-download-by-ec2s/amazon-ebs-autoscale/
+aws s3 sync . s3://source-code-for-download-by-ec2s/amazon-ebs-autoscale/ --exclude .git*

--- a/s3_sync_to_test.sh
+++ b/s3_sync_to_test.sh
@@ -1,1 +1,1 @@
-aws s3 sync . s3://embark-pcluster/amazon-ebs-autoscale/ --exclude .git*
+aws s3 sync . s3://embark-pcluster/amazon-ebs-autoscale/ --exclude "*.git*"

--- a/s3_sync_to_test.sh
+++ b/s3_sync_to_test.sh
@@ -1,1 +1,1 @@
-aws s3 sync . s3://embark-pcluster/amazon-ebs-autoscale/
+aws s3 sync . s3://embark-pcluster/amazon-ebs-autoscale/ --exclude .git*


### PR DESCRIPTION
Added retry logic to the `modify-instance-attribute` to ensure the `DeleteOnTerminatation` attribute is set to `true`. 

If we continue to see EBS volumes persist beyond the instance's lifespan, then we know that the volumes are failing to attach and the subsequent delete volume calls are also failing

```
[Fri Feb 19 19:15:29 UTC 2021] LOW DISK (52%): Adding more.
[Fri Feb 19 19:15:29 UTC 2021] Extending logical volume /scratch by 256GB
[Fri Feb 19 19:15:29 UTC 2021] Trying /dev/nvme1n1
[Fri Feb 19 19:15:29 UTC 2021] Trying /dev/nvme2n1
[Fri Feb 19 19:15:29 UTC 2021] Trying /dev/nvme3n1
[Fri Feb 19 19:15:29 UTC 2021] Available device found /dev/nvme3n1
[Fri Feb 19 19:15:29 UTC 2021] next available device: /dev/nvme3n1
[Fri Feb 19 19:15:30 UTC 2021] created volume: vol-0321ab5addea79f54 [ --size 256 --volume-type gp2 --encrypted ]
[Fri Feb 19 19:15:46 UTC 2021] volume vol-0321ab5addea79f54 available
[Fri Feb 19 19:15:46 UTC 2021] attaching volume vol-0321ab5addea79f54
[Fri Feb 19 19:15:48 UTC 2021] waiting for volume vol-0321ab5addea79f54 on filesystem, device /dev/nvme3n1, /dev/xvdbc
[Fri Feb 19 19:15:49 UTC 2021] volume vol-0321ab5addea79f54 on filesystem as /dev/nvme3n1, /dev/xvdbc
[Fri Feb 19 19:15:50 UTC 2021] volume vol-0321ab5addea79f54 DeleteOnTermination ENABLED
[Fri Feb 19 19:15:50 UTC 2021] Adding device /dev/nvme3n1 to logical volume /scratch
[Fri Feb 19 19:15:50 UTC 2021] Finished extending logical volume
```
